### PR TITLE
connect remote MYSQL service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### enviorment value ###
+application-DATABASE.properties

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,10 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'mysql:mysql-connector-java'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'javax.persistence:javax.persistence-api:2.2'
+	implementation 'javax.xml.bind:jaxb-api:2.2.4'
 }
 
 test {

--- a/src/main/java/grabit/grabit_backend/Domain/User.java
+++ b/src/main/java/grabit/grabit_backend/Domain/User.java
@@ -1,0 +1,39 @@
+package grabit.grabit_backend.Domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class User {
+
+	@Id
+	@GeneratedValue
+	private Long id;
+	private String name;
+	private String password;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+}

--- a/src/main/java/grabit/grabit_backend/GrabitBackendApplication.java
+++ b/src/main/java/grabit/grabit_backend/GrabitBackendApplication.java
@@ -1,13 +1,21 @@
 package grabit.grabit_backend;
 
+import grabit.grabit_backend.Domain.User;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityTransaction;
+import javax.persistence.PersistenceContext;
 
 @SpringBootApplication
 public class GrabitBackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(GrabitBackendApplication.class, args);
+
+
 	}
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+spring.profiles.include=DATABASE


### PR DESCRIPTION
## PR 타입(하나 이상 선택해주세요.)

- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수 업데이트
- [ ] 기타

## 배경(Backgroud)

* DBMS 서비스를 이용하기 위해 aws RDB 서비스를 이용해야 함.
* mysql로 RDB 서비스를 생성했고, URL, Id, Password는 Properties파일 작성하여 중요한 정보를 숨김.
* 그로 인해 EntityManager를 구성하는 방법은 따로 babel을 통해 구성해야 한다고 함.


## 변경사항(Changes)

* application-DATABASE.properties 파일에 DB 관련 정보를 저장하였음.
* 해당 파일은 src/main/resources/application-DATABASE.properties에 위치하도록 따로 파일을 저장해야 함. (구글 드라이브에 업로드 함)
* .gitignore을 사용하여 민감한 정보의 노출을 숨김.
* build, deploy마다 설정을 다르게 하는 것은 resource 디렉토리를 새로 파서 JVM 명령어를 따로 줘야 한다고 함. (추후 할 예정)
* 현재 Domain 디렉토리에 임시 멤버를 구성했는데, Jpa 서비스 정상 작동 됨.


## 결과(Result)

* 정상적으로 서버 연결 됨.
* 임시 member Entity를 만들고 샏성한 결과 원격 mysql 서버에 정상적으로 등록 됨.

![image](https://user-images.githubusercontent.com/62492860/148886201-97ce71be-3845-4933-9ac2-da1f03cb9874.png)


