### PR TITLE
Feat: get /user API 작성

### DIFF
--- a/src/main/java/grabit/grabit_backend/Controller/UserController.java
+++ b/src/main/java/grabit/grabit_backend/Controller/UserController.java
@@ -1,0 +1,30 @@
+package grabit.grabit_backend.Controller;
+
+import grabit.grabit_backend.DTO.UserResDTO;
+import grabit.grabit_backend.Domain.User;
+import grabit.grabit_backend.exception.UnauthorizedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.Collections;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    @GetMapping("/")
+    public ResponseEntity<UserResDTO> user(@AuthenticationPrincipal User user) {
+        if (user == null) {
+          throw new UnauthorizedException();
+        }
+        UserResDTO resDTO = new UserResDTO(user);
+        return ResponseEntity.status(HttpStatus.OK).body(resDTO);
+    }
+
+}

--- a/src/main/java/grabit/grabit_backend/Controller/UserController.java
+++ b/src/main/java/grabit/grabit_backend/Controller/UserController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<UserResDTO> user(@AuthenticationPrincipal User user) {
         if (user == null) {
           throw new UnauthorizedException();

--- a/src/main/java/grabit/grabit_backend/DTO/UserResDTO.java
+++ b/src/main/java/grabit/grabit_backend/DTO/UserResDTO.java
@@ -1,0 +1,52 @@
+package grabit.grabit_backend.DTO;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import grabit.grabit_backend.Domain.User;
+import lombok.Getter;
+import lombok.Setter;
+
+public class UserResDTO {
+    private int id;
+    private String githubId;
+    private String username;
+    private String userEmail;
+
+    public UserResDTO(User user) {
+        this.id = user.getId();
+        this.githubId = user.getUserId();
+        this.username = user.getUsername();
+        this.userEmail = user.getUserEmail();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getGithubId() {
+        return githubId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public void setGithubId(String githubId) {
+        this.githubId = githubId;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+}

--- a/src/main/java/grabit/grabit_backend/exception/UnauthorizedException.java
+++ b/src/main/java/grabit/grabit_backend/exception/UnauthorizedException.java
@@ -1,0 +1,14 @@
+package grabit.grabit_backend.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "Unauthorized")
+public class UnauthorizedException extends RuntimeException{
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+    public UnauthorizedException() {
+        super("로그인이 필요합니다.");
+    }
+}


### PR DESCRIPTION
- Bearer Token과 함께 get /user 요청 시, 해당 user의 정보가 res됨
- Token이 없을 경우 401

## PR 타입(하나 이상 선택해주세요.)

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수 업데이트
- [ ] 기타

## 배경(Backgroud)

* token을 담아보내면 user 정보를 내려주는 API 필요

## 변경사항(Changes)

* GET /api/user 작성


## 결과(Result)

* 유효한 token을 담아 보낼 때의 res

```
{
    "id": 43634786,
    "githubId": "sally0226",
    "username": "sally0226",
    "userEmail": "sally0226@naver.com"
}
```

* 유효하지 않은 token이나, 아무 것도 담아보내지 않을 때의 res

```
{
    "timestamp": "2022-02-12T13:22:57.310+00:00",
    "status": 401,
    "error": "Unauthorized",
    "path": "/user"
}
```