### PR TITLE
Feat: jsessionId url 노출 안되게 설정

### DIFF
--- a/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
+++ b/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import grabit.grabit_backend.Repository.UserRefreshTokenRepository;
 import grabit.grabit_backend.auth.JwtAuthenticationFilter;
 import grabit.grabit_backend.auth.JwtProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,12 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import java.util.Collections;
 
 @Configuration
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
@@ -35,6 +42,19 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         this.userRefreshTokenRepository = userRefreshTokenRepository;
         this.clientRegistrationRepository = clientRegistrationRepository;
     }
+
+    @Bean
+    public ServletContextInitializer clearJsession() {
+        return new ServletContextInitializer() {
+            @Override
+            public void onStartup(ServletContext servletContext) throws ServletException {
+                servletContext.setSessionTrackingModes(Collections.singleton(SessionTrackingMode.COOKIE));
+                SessionCookieConfig sessionCookieConfig=servletContext.getSessionCookieConfig();
+                sessionCookieConfig.setHttpOnly(true);
+            }
+        };
+    }
+
 
     /**
      * OAuth 인증 성공 핸들러


### PR DESCRIPTION
## PR 타입(하나 이상 선택해주세요.)

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수 업데이트
- [ ] 기타

## 배경(Backgroud)

- 서버가 열리고 최초 oauth2 로그인 요청시에 리다이렉트 uri에 jsessionId가 불필요하게 포함되었음
- 원래 jsessionId를 쿠키로 주고받는데, 최초 요청시에는 클라이언트쪽이 쿠키를 사용하는지 모르기 때문에 uri에 넣어준다고 함

## 변경사항(Changes)

- 따라서, 애초에 처음부터 쿠키에 넣어주도록 설정해 uri에 뜨지 않도록 함


## 결과(Result)

* jsessionId가 uri에 노출되지 않음

