### PR TITLE
Challenge 가입, 삭제 logic 추가.

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -97,6 +97,7 @@ public class ChallengeController {
 	public ResponseEntity<ResponseChallengeDTO> joinChallengeAPI(@PathVariable(value = "id") Long id,
 																 @AuthenticationPrincipal User user){
 		ResponseChallengeDTO responseChallengeDTO = challengeService.joinChallenge(id, user);
+
 		return ResponseEntity.status(HttpStatus.OK).body(responseChallengeDTO);
 	}
 

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -27,7 +27,7 @@ public class ChallengeController {
 
 	/**
 	 * 모든 챌린지 검색 API
-	 * @return List of Challenge
+	 * @return responseEntity
 	 */
 	@GetMapping(value = "")
 	public ResponseEntity<ArrayList<ResponseChallengeDTO>> findAllChallengesAPI(){
@@ -38,10 +38,12 @@ public class ChallengeController {
 	/**
 	 * 챌린지 생성 API
 	 * @param createChallengeDTO
-	 * @return responseChallengeDTO
+	 * @param user
+	 * @return responseEntity
 	 */
 	@PostMapping(value = "")
-	public ResponseEntity<ResponseChallengeDTO> createChallengeAPI(@Valid @RequestBody CreateChallengeDTO createChallengeDTO, @AuthenticationPrincipal User user){
+	public ResponseEntity<ResponseChallengeDTO> createChallengeAPI(@Valid @RequestBody CreateChallengeDTO createChallengeDTO,
+																   @AuthenticationPrincipal User user){
 		ResponseChallengeDTO responseChallengeDTO = challengeService.createChallenge(createChallengeDTO, user);
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseChallengeDTO);
 	}
@@ -50,11 +52,13 @@ public class ChallengeController {
 	 * 챌린지 수정 API
 	 * @param id
 	 * @param modifyChallengeDTO
-	 * @return responseChallengeDTO
+	 * @param user
+	 * @return responseEntity
 	 */
 	@PatchMapping(value = "{id}")
 	public ResponseEntity<ResponseChallengeDTO> updateChallengeAPI(@PathVariable(value = "id") Long id,
-										@Valid @RequestBody ModifyChallengeDTO modifyChallengeDTO, @AuthenticationPrincipal User user){
+																   @Valid @RequestBody ModifyChallengeDTO modifyChallengeDTO,
+																   @AuthenticationPrincipal User user){
 		ResponseChallengeDTO responseChallengeDTO = challengeService.updateChallenge(id, modifyChallengeDTO, user);
 		return ResponseEntity.status(HttpStatus.CREATED).body(responseChallengeDTO);
 	}
@@ -62,9 +66,12 @@ public class ChallengeController {
 	/**
 	 * 챌린지 삭제 API
 	 * @param id
+	 * @param user
+	 * @return responseEntity
 	 */
 	@DeleteMapping(value = "{id}")
-	public ResponseEntity<Void> deleteChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user){
+	public ResponseEntity<Void> deleteChallengeAPI(@PathVariable(value = "id") Long id,
+												   @AuthenticationPrincipal User user){
 		challengeService.deleteChallengeById(id, user);
 		return ResponseEntity.status(HttpStatus.OK).build();
 	}
@@ -72,7 +79,7 @@ public class ChallengeController {
 	/**
 	 * 챌린지 검색 API
 	 * @param id
-	 * @return responseChallengeDTO
+	 * @return responseEntity
 	 */
 	@GetMapping(value = "{id}")
 	public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id){
@@ -80,15 +87,29 @@ public class ChallengeController {
 		return ResponseEntity.status(HttpStatus.OK).body(responseChallengeDTO);
 	}
 
+	/**
+	 * 챌린지 가입 API
+	 * @param id
+	 * @param user
+	 * @return
+	 */
 	@PatchMapping(value = "{id}/join")
-	public ResponseEntity<ResponseChallengeDTO> joinChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user){
+	public ResponseEntity<ResponseChallengeDTO> joinChallengeAPI(@PathVariable(value = "id") Long id,
+																 @AuthenticationPrincipal User user){
 		ResponseChallengeDTO responseChallengeDTO = challengeService.joinChallenge(id, user);
 		return ResponseEntity.status(HttpStatus.OK).body(responseChallengeDTO);
 	}
 
+	/**
+	 * 챌린지 탈퇴 API
+	 * @param id
+	 * @param user
+	 * @return
+	 */
 	@PatchMapping(value = "{id}/leave")
-	public ResponseEntity<ResponseChallengeDTO> leaveChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user){
-		ResponseChallengeDTO responseChallengeDTO = challengeService.leaveChallenge(id, user);
-		return ResponseEntity.status(HttpStatus.OK).body(responseChallengeDTO);
+	public ResponseEntity<Void> leaveChallengeAPI(@PathVariable(value = "id") Long id,
+												  @AuthenticationPrincipal User user){
+		challengeService.leaveChallenge(id, user);
+		return ResponseEntity.status(HttpStatus.OK).build();
 	}
 }

--- a/src/main/java/grabit/grabit_backend/domain/Challenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/Challenge.java
@@ -1,10 +1,13 @@
 package grabit.grabit_backend.domain;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import javax.persistence.*;
 
 @Getter
@@ -29,6 +32,9 @@ public class Challenge extends BaseEntity {
 	private LocalDateTime createdAt;
 	private LocalDateTime modifiedAt;
 
+	@OneToMany(mappedBy = "challenge")
+	private List<UserChallenge> userChallengeList = new ArrayList<>();
+
 	@ManyToOne(optional = false)
 	@JoinColumn(name="LEADER_ID")
 	private User leader;
@@ -42,9 +48,10 @@ public class Challenge extends BaseEntity {
 		this.isPrivate = isPrivate;
 	}
 
-	public void modifyChallenge(ModifyChallengeDTO modifyChallengeDTO) {
+	public void modifyChallenge(ModifyChallengeDTO modifyChallengeDTO, User leader) {
 		this.name = modifyChallengeDTO.getName();
 		this.description = modifyChallengeDTO.getDescription();
 		this.isPrivate = modifyChallengeDTO.getIsPrivate();
+		this.leader = leader;
 	}
 }

--- a/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
@@ -28,7 +28,7 @@ public class UserChallenge {
 
 	@Id
 	@ManyToOne
-	@JoinColumn(name = "ID")
+	@JoinColumn(name = "USER_ID")
 	private User user;
 
 	@Id

--- a/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
@@ -2,6 +2,7 @@ package grabit.grabit_backend.domain;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -20,6 +21,7 @@ import javax.persistence.ManyToOne;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class UserChallenge {
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "USER_CHALLENGE_ID")

--- a/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
@@ -28,7 +28,7 @@ public class UserChallenge {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "ID")
+	@JoinColumn(name = "USER_ID")
 	private User user;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
@@ -13,6 +13,7 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
@@ -22,16 +23,16 @@ import javax.persistence.ManyToOne;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@IdClass(UserChallengePK.class)
 public class UserChallenge {
-	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "USER_CHALLENGE_ID")
-	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "USER_ID")
+	@Id
+	@ManyToOne
+	@JoinColumn(name = "ID")
 	private User user;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@Id
+	@ManyToOne
 	@JoinColumn(name = "CHALLENGE_ID")
 	private Challenge challenge;
 }

--- a/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallenge.java
@@ -1,5 +1,6 @@
 package grabit.grabit_backend.domain;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Setter;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -23,11 +25,11 @@ public class UserChallenge {
 	@Column(name = "USER_CHALLENGE_ID")
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "ID")
 	private User user;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "CHALLENGE_ID")
 	private Challenge challenge;
 }

--- a/src/main/java/grabit/grabit_backend/domain/UserChallengePK.java
+++ b/src/main/java/grabit/grabit_backend/domain/UserChallengePK.java
@@ -1,0 +1,15 @@
+package grabit.grabit_backend.domain;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+public class UserChallengePK implements Serializable {
+	private Integer user;
+	private Long challenge;
+}

--- a/src/main/java/grabit/grabit_backend/dto/ModifyChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/ModifyChallengeDTO.java
@@ -1,15 +1,27 @@
 package grabit.grabit_backend.dto;
 
+import grabit.grabit_backend.domain.User;
 import lombok.Getter;
 import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 @Getter
 @Setter
 public class ModifyChallengeDTO {
 
+	@NotBlank
 	private String name;
+
+	@NotNull
 	private String description;
+
+	@NotBlank
 	private String leader;
+
+	@NotNull
 	private Boolean isPrivate;
 
 }

--- a/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
@@ -20,7 +20,7 @@ public class ResponseChallengeDTO {
 	private final Long id;
 	private final String name;
 	private final String description;
-	private final User leader;
+	private final String leader;
 	private final Boolean isPrivate;
 	private final List<String> member;
 
@@ -33,7 +33,7 @@ public class ResponseChallengeDTO {
 				challenge.getId(),
 				challenge.getName(),
 				challenge.getDescription(),
-				challenge.getLeader(),
+				challenge.getLeader().getUserId(),
 				challenge.getIsPrivate(),
 				members
 		);

--- a/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
@@ -2,25 +2,41 @@ package grabit.grabit_backend.dto;
 
 import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
+import grabit.grabit_backend.domain.UserChallenge;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
-@Setter
 @AllArgsConstructor
-@ToString
 public class ResponseChallengeDTO {
 
-	private Long id;
-	private String name;
-	private String description;
-	private User leader;
-	private Boolean isPrivate;
+	private final Long id;
+	private final String name;
+	private final String description;
+	private final User leader;
+	private final Boolean isPrivate;
+	private final List<String> member;
 
 	public static ResponseChallengeDTO convertDTO(Challenge challenge){
-		return new ResponseChallengeDTO(challenge.getId(), challenge.getName(), challenge.getDescription(), challenge.getLeader(), challenge.getIsPrivate());
+		// 순환 참조를 방지하기 위해 데이터를 담아서 보냄.
+		List<String> members = new ArrayList<>();
+		challenge.getUserChallengeList().forEach(x -> members.add(x.getUser().getUserId()));
+
+		return new ResponseChallengeDTO(
+				challenge.getId(),
+				challenge.getName(),
+				challenge.getDescription(),
+				challenge.getLeader(),
+				challenge.getIsPrivate(),
+				members
+		);
 	}
 
 }

--- a/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
@@ -1,8 +1,13 @@
 package grabit.grabit_backend.repository;
 
+import grabit.grabit_backend.domain.Challenge;
+import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.domain.UserChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
 	UserChallenge save(UserChallenge userChallenge);
+	void deleteByUserAndChallenge(User user, Challenge challenge);
 }

--- a/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
@@ -3,6 +3,7 @@ package grabit.grabit_backend.repository;
 import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.domain.UserChallenge;
+import grabit.grabit_backend.domain.UserChallengePK;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
+public interface UserChallengeRepository extends JpaRepository<UserChallenge, UserChallengePK> {
 	UserChallenge save(UserChallenge userChallenge);
 	Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
+	void deleteByUserAndChallenge(User user, Challenge challenge);
+	void deleteAllByUserAndChallenge(User user, Challenge challenge);
 }

--- a/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/UserChallengeRepository.java
@@ -4,10 +4,13 @@ import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.domain.UserChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
 	UserChallenge save(UserChallenge userChallenge);
-	void deleteByUserAndChallenge(User user, Challenge challenge);
+	Optional<UserChallenge> findByUserAndChallenge(User user, Challenge challenge);
 }

--- a/src/main/java/grabit/grabit_backend/repository/UserRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/UserRepository.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Integer> {
     User save(User user);
     Optional<User> findById(Integer Id);
+    Optional<User> findByUserId(String userId);
     List<User> findAll();
     void deleteById(Integer id);
 }

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -159,7 +159,11 @@ public class ChallengeService {
 	public void leaveChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
-		userChallengeRepository.deleteByUserAndChallenge(user, findChallenge);
+		Optional<UserChallenge> finduserChallenge = userChallengeRepository.findByUserAndChallenge(user, findChallenge);
+		if(finduserChallenge.isEmpty()){
+			throw new IllegalStateException("잘못된 요청입니다.");
+		}
+		userChallengeRepository.delete(finduserChallenge.get());
 	}
 
 	private Challenge isExistChallenge(Long id){

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -61,6 +61,7 @@ public class ChallengeService {
 	 * @param id
 	 * @return Challenge
 	 */
+	@Transactional
 	public ResponseChallengeDTO findChallengeById(Long id){
 		Challenge challenge = isExistChallenge(id);
 		return ResponseChallengeDTO.convertDTO(challenge);
@@ -71,6 +72,7 @@ public class ChallengeService {
 	 * @param name
 	 * @return List of Challenge
 	 */
+	@Transactional
 	public ArrayList<ResponseChallengeDTO> findChallengeByName(String name){
 		List<Challenge> findChallenges = challengeRepository.findByName(name);
 		ArrayList<ResponseChallengeDTO> returnChallenges = new ArrayList<>();
@@ -84,6 +86,7 @@ public class ChallengeService {
 	 * 챌린지 삭제
 	 * @param id
 	 */
+	@Transactional
 	public void deleteChallengeById(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
@@ -101,6 +104,7 @@ public class ChallengeService {
 	 * @param modifyChallengeDTO
 	 * @return Challenge
 	 */
+	@Transactional
 	public ResponseChallengeDTO updateChallenge(Long id, ModifyChallengeDTO modifyChallengeDTO, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
@@ -122,6 +126,7 @@ public class ChallengeService {
 	 * 모든 챌린지 검색
 	 * @return ArrayList of ResponseChallengeDTO
 	 */
+	@Transactional
 	public ArrayList<ResponseChallengeDTO> findAllChallenge(){
 		List<Challenge> findChallenges = challengeRepository.findAll();
 		ArrayList<ResponseChallengeDTO> returnChallenges = new ArrayList<>();
@@ -137,6 +142,7 @@ public class ChallengeService {
 	 * @param user
 	 * @return
 	 */
+	@Transactional
 	public ResponseChallengeDTO joinChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
@@ -155,15 +161,10 @@ public class ChallengeService {
 	 * @param user
 	 * @return
 	 */
+	@Transactional
 	public void leaveChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
-		Optional<UserChallenge> finduserChallenge = userChallengeRepository.findByUserAndChallenge(user, findChallenge);
-		if(finduserChallenge.isEmpty()){
-			throw new IllegalStateException("잘못된 요청입니다.");
-		}
-//		userChallengeRepository.delete(finduserChallenge.get());
-		userChallengeRepository.findAll()
 		userChallengeRepository.deleteByUserAndChallenge(user, findChallenge);
 	}
 

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -157,6 +157,8 @@ public class ChallengeService {
 				.build();
 
 		userChallengeRepository.save(userChallenge);
+		findChallenge.getUserChallengeList().add(userChallenge);
+
 		return ResponseChallengeDTO.convertDTO(findChallenge);
 	}
 

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -146,8 +146,7 @@ public class ChallengeService {
 				.build();
 
 		userChallengeRepository.save(userChallenge);
-		Challenge modifiedChallenge = challengeRepository.save(findChallenge);
-		return ResponseChallengeDTO.convertDTO(modifiedChallenge);
+		return ResponseChallengeDTO.convertDTO(findChallenge);
 	}
 
 	/**
@@ -163,7 +162,9 @@ public class ChallengeService {
 		if(finduserChallenge.isEmpty()){
 			throw new IllegalStateException("잘못된 요청입니다.");
 		}
-		userChallengeRepository.delete(finduserChallenge.get());
+//		userChallengeRepository.delete(finduserChallenge.get());
+		userChallengeRepository.findAll()
+		userChallengeRepository.deleteByUserAndChallenge(user, findChallenge);
 	}
 
 	private Challenge isExistChallenge(Long id){

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -41,7 +41,11 @@ public class ChallengeService {
 	 */
 	@Transactional
 	public ResponseChallengeDTO createChallenge(CreateChallengeDTO createChallengeDTO, User user){
-		Challenge challenge = new Challenge(createChallengeDTO.getName(), createChallengeDTO.getDescription(), createChallengeDTO.getIsPrivate(), user);
+		Challenge challenge = new Challenge(createChallengeDTO.getName(),
+				createChallengeDTO.getDescription(),
+				createChallengeDTO.getIsPrivate(),
+				user
+		);
 		Challenge createChallenge = challengeRepository.save(challenge);
 
 		UserChallenge userChallenge = new UserChallenge();
@@ -87,6 +91,7 @@ public class ChallengeService {
 		if(findChallenge.getLeader().getUserId() != user.getUserId()){
 			throw new UnauthorizedException();
 		}
+
 		challengeRepository.deleteById(id);
 	}
 
@@ -135,6 +140,12 @@ public class ChallengeService {
 	public ResponseChallengeDTO joinChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
+		UserChallenge userChallenge = UserChallenge.builder()
+				.user(user)
+				.challenge(findChallenge)
+				.build();
+
+		userChallengeRepository.save(userChallenge);
 		Challenge modifiedChallenge = challengeRepository.save(findChallenge);
 		return ResponseChallengeDTO.convertDTO(modifiedChallenge);
 	}
@@ -145,11 +156,10 @@ public class ChallengeService {
 	 * @param user
 	 * @return
 	 */
-	public ResponseChallengeDTO leaveChallenge(Long id, User user){
+	public void leaveChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
-		Challenge modifiedChallenge = challengeRepository.save(findChallenge);
-		return ResponseChallengeDTO.convertDTO(modifiedChallenge);
+		userChallengeRepository.deleteByUserAndChallenge(user, findChallenge);
 	}
 
 	private Challenge isExistChallenge(Long id){

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -146,6 +146,11 @@ public class ChallengeService {
 	public ResponseChallengeDTO joinChallenge(Long id, User user){
 		Challenge findChallenge = isExistChallenge(id);
 
+		Optional<UserChallenge> findUserChallenge = userChallengeRepository.findByUserAndChallenge(user, findChallenge);
+		if(findUserChallenge.isPresent()){
+			throw new IllegalStateException("이미 가입한 유저입니다.");
+		}
+
 		UserChallenge userChallenge = UserChallenge.builder()
 				.user(user)
 				.challenge(findChallenge)


### PR DESCRIPTION
## PR 타입(하나 이상 선택해주세요.)

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수 업데이트
- [ ] 기타

## 배경(Backgroud)

* 다대다 맵핑을 통한 User-Challenge간 연관관계 설정 필요.


## 변경사항(Changes)

* 새로운 Domain으로 연관관계 설정함.
* 챌린지 가입 시 유저와 챌린지 연관된 저장소에 저장되도록 변경.


## 결과(Result)

* 챌린지 가입 시 UserChallenge에 가입 정보 추가됨.

