### PR TITLE
Feat: oauth login callback url 수정

### DIFF
--- a/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
+++ b/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package grabit.grabit_backend.config.security;
 
+import grabit.grabit_backend.Oauth2.handler.CustomAuthorizationRequestResolver;
 import grabit.grabit_backend.Oauth2.handler.CustomOAuth2UserService;
 import grabit.grabit_backend.Oauth2.handler.OAuth2AuthenticationSuccessHandler;
 import grabit.grabit_backend.Oauth2.repository.CustomAuthorizationRequestRepository;
@@ -78,14 +79,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .authorizeRequests()
-                    .antMatchers("/oauth2/**").permitAll()
+                    .antMatchers("/api/login/**").permitAll()
                     .antMatchers("/api/oauth2/**").permitAll()
+                    .antMatchers("/api").permitAll() // local에서 oauth로그인 시 redirect받을 링크
                     .antMatchers("/api/**").hasAnyRole("USER")
                 .and()
                 .oauth2Login()
+//                    .redirectionEndpoint()
+//                    .baseUri("/api/login/oauth2/code/**")
+//                .and()
                 .authorizationEndpoint()
                         .authorizationRequestRepository(customAuthorizationRequestRepository())
-                        .authorizationRequestResolver(new CustomAuthorizationRequestResolver(clientRegistrationRepository, "/api/oauth2/authorization"))
+//                        .authorizationRequestResolver(new CustomAuthorizationRequestResolver(clientRegistrationRepository, "/api/oauth2/authorization"))
                 .and()
                     .successHandler(oAuth2AuthenticationSuccessHandler())
                     .userInfoEndpoint()

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -15,7 +15,7 @@ import javax.validation.Valid;
 import java.util.ArrayList;
 
 @RestController
-@RequestMapping("api/challenges")
+@RequestMapping("challenges")
 public class ChallengeController {
 
 	private final ChallengeService challengeService;

--- a/src/main/java/grabit/grabit_backend/controller/UserController.java
+++ b/src/main/java/grabit/grabit_backend/controller/UserController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("users")
 public class UserController {
     @GetMapping("")
     public ResponseEntity<UserResDTO> user(@AuthenticationPrincipal User user) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.profiles.include=DATABASE
-#server.servlet.context-path=/api
+server.servlet.context-path=/api


### PR DESCRIPTION
## 배경(Backgroud)
-  `server.servlet.context-path=/api` 옵션을 통해 모든 endpoint가 `/api`로 시작하도록 설정하여
- 매번 controller에 `/api`를 붙여주지 않아도 되게 하고싶었음

- 하지만 oauth callback url이 `/api`로 시작하지 않아 적용하지 못하고 있었음

## 변경사항(Changes)

- oauth callback url을 `/api/login/oauth2/code/github` 형태로 앞에 `/api`가 붙도록 수정

- `application.yml` 수정 (swit에 올려놓음)

## 결과(Result)

- 이로써 모든 url이 /api로 시작하므로
    - server.servlet.context-path=/api 옵션 추가
    - 각 Controller 파일에 /api 제거


