### PR TITLE
[S3 bucket] Image 브라우저에 띄우기, 파일이름 수정.

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/S3Controller.java
+++ b/src/main/java/grabit/grabit_backend/controller/S3Controller.java
@@ -15,7 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 
 @RestController
-@RequestMapping("api/s3")
+@RequestMapping("image")
 public class S3Controller {
 
 	private S3Service s3Service;

--- a/src/main/java/grabit/grabit_backend/controller/S3Controller.java
+++ b/src/main/java/grabit/grabit_backend/controller/S3Controller.java
@@ -1,9 +1,11 @@
 package grabit.grabit_backend.controller;
 
+import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.service.S3Service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +26,10 @@ public class S3Controller {
 	}
 
 	@PostMapping(value = "")
-	public ResponseEntity<String> execWrite(MultipartFile file) throws IOException {
+	public ResponseEntity<String> execWrite(@AuthenticationPrincipal User user,
+											MultipartFile file) throws IOException {
 		System.out.println(file.getName());
-		String result = s3Service.upload(file);
+		String result = s3Service.upload(user, file);
 
 		return ResponseEntity.status(HttpStatus.OK).body(result);
 	}


### PR DESCRIPTION
## PR 타입(하나 이상 선택해주세요.)

- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수 업데이트
- [x] 기타

## 배경(Backgroud)

* Image를 불러오는 과정에서 브라우저에 띄우지 않고 다운로드 되는 방식이었음.
* 파일 이름이 사용자가 저장한 이름을 그대로 가져다 쓰기 때문에, 파일 이름이 같으면 중복되서 지워지고 있었음.


## 변경사항(Changes)

* image content-type을 image/jpg 로 변경하고 업로드하면 브라우저에 불러옴.
* UUID random 함수를 통해 (user_id) + UUID 값으로 중복을 방지함.


## 결과(Result)

* <img width="1233" alt="image" src="https://user-images.githubusercontent.com/62492860/159117451-08799005-20f1-4713-99df-36882baf8b50.png">

