### PR TITLE
Fix: 권한 적용 url 설정 변경

### DIFF
--- a/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
+++ b/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
@@ -31,16 +31,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final JwtProvider jwtProvider;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
-    private final ClientRegistrationRepository clientRegistrationRepository;
 
     @Autowired
     public SecurityConfig(CustomOAuth2UserService customOAuth2UserService,
                           JwtProvider jwtProvider,
-                          UserRefreshTokenRepository userRefreshTokenRepository, ClientRegistrationRepository clientRegistrationRepository) {
+                          UserRefreshTokenRepository userRefreshTokenRepository) {
         this.customOAuth2UserService = customOAuth2UserService;
         this.jwtProvider = jwtProvider;
         this.userRefreshTokenRepository = userRefreshTokenRepository;
-        this.clientRegistrationRepository = clientRegistrationRepository;
     }
 
     @Bean
@@ -79,18 +77,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
                 )
                 .authorizeRequests()
-                    .antMatchers("/api/login/**").permitAll()
-                    .antMatchers("/api/oauth2/**").permitAll()
-                    .antMatchers("/api").permitAll() // local에서 oauth로그인 시 redirect받을 링크
-                    .antMatchers("/api/**").hasAnyRole("USER")
+                    .antMatchers("/login/**").permitAll()
+                    .antMatchers("/oauth2/**").permitAll()
+                    .antMatchers("/").permitAll() // local에서 oauth로그인 시 redirect받을 링크
+                    .antMatchers("/**").hasAnyRole("USER")
                 .and()
                 .oauth2Login()
-//                    .redirectionEndpoint()
-//                    .baseUri("/api/login/oauth2/code/**")
-//                .and()
                 .authorizationEndpoint()
                         .authorizationRequestRepository(customAuthorizationRequestRepository())
-//                        .authorizationRequestResolver(new CustomAuthorizationRequestResolver(clientRegistrationRepository, "/api/oauth2/authorization"))
                 .and()
                     .successHandler(oAuth2AuthenticationSuccessHandler())
                     .userInfoEndpoint()


### PR DESCRIPTION
## 배경(Backgroud)

* 로그인을 하지 않은 상태에서 /api/challenges 에 접근이 되는 버그 발견


## 변경사항(Changes)

- `server.servlet.context-path=/api`를 적용하면서 생긴 문제였음
- `/api/**`에 권한이 적용되어야 하는데, `/api/api/**`에 권한이 적용되고 있었음
- Spring Config내의 권한적용하는 URL들에서 `/api` prefix 제거

- Spring Config내의 불필요한 주석, 코드 제거

## 결과(Result)

- 의도했던대로 권한이 잘 적용되었다

