### PR TITLE
[JPA] Paging과 fetch join을 같이 사용하면 생기는 메모리 문제 해결.

### DIFF
--- a/src/main/java/grabit/grabit_backend/domain/Challenge.java
+++ b/src/main/java/grabit/grabit_backend/domain/Challenge.java
@@ -35,7 +35,7 @@ public class Challenge extends BaseEntity {
 	@Column(name = "IS_PRIVATE")
 	private Boolean isPrivate;
 
-	@OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE)
+	@OneToMany(mappedBy = "challenge", cascade = CascadeType.REMOVE, fetch = FetchType.EAGER)
 	@JsonManagedReference
 	private List<UserChallenge> userChallengeList = new ArrayList<>();
 

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -36,7 +36,6 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	public List<Challenge> findAllChallengeWithPaging(Pageable pageable) {
 		return jpaQueryFactory
 				.selectFrom(challenge)
-				.join(challenge.userChallengeList, userChallenge).fetchJoin()
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();


### PR DESCRIPTION
## 배경(Backgroud)

* 1:N 관계에서 Paging과 fetch join을 같이 사용하면 memory 문제가 생김.
* fetch join을 할 경우 row가 증가하면서 기존에 paging에서 조회하던 SQL limit이 정상적으로 나가지 않게 되어있음.
* 해결방법은 fetch join을 사용하지 않고 paging을 처리해서 limit한 결과를 가져오고, 그 결과에 대해 join을 batch로 수행함.
* 자세한 내용은 여기 [링크](https://tecoble.techcourse.co.kr/post/2020-10-21-jpa-fetch-join-paging/)를 참고하면 됩니다.


## 변경사항(Changes)

* EAGER로 userChallenge를 limit만큼 가져올때 같이 가져오도록 함. LAZY로 하면 userChallenge를 하나씩 가져오는 쿼리가 계속 발생. (bf1c9d3)


## 결과(Result)

* findAll 요청 시 발생하던 정상적으로 limit을 호출하고, memory 누수 경고가 발생하지 않음.

