### PR TITLE
[Challenge] Paging Response 수정.

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -61,6 +61,18 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ env.AWS_REGION }}
 
+    - name: Create application-prod.properties
+      run: |
+        cd ./src/main/resources
+        echo "${{ secret.APPLICATION_DATABASE }}" > application-DATABASE.properties
+        echo "${{ secret.APPLICATION_STOREAGE }}" > application-STOREAGE.properties
+        echo "${{ secret.APPLICATION }}" > application.yml
+        echo "${{ secret.LOGBACK }}" > logback.xml
+      shell: bash
+
+    - name: Build with Gradle
+      run: ./gradlew bootJar
+
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v1

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -5,6 +5,7 @@ import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import grabit.grabit_backend.dto.ResponseChallengeDTO;
 import grabit.grabit_backend.domain.User;
+import grabit.grabit_backend.dto.ResponsePagingDTO;
 import grabit.grabit_backend.service.ChallengeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("challenges")
@@ -35,10 +37,10 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "")
-	public ResponseEntity<List<Challenge>> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
-																		@RequestParam(defaultValue = "5") Integer size){
-		List<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(findChallengesWithPage);
+	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+																		  @RequestParam(defaultValue = "5") Integer size){
+		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/ResponseChallengeDTO.java
@@ -9,9 +9,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -37,6 +39,24 @@ public class ResponseChallengeDTO {
 				challenge.getIsPrivate(),
 				members
 		);
+	}
+
+	public static ResponsePagingDTO convertPageDTO(Page<Challenge> challengePage){
+		List<ResponseChallengeDTO> challengeDTOList = new ArrayList<>();
+		challengePage.getContent().forEach(x -> challengeDTOList.add(convertDTO(x)));
+
+		return ResponsePagingDTO.builder()
+				.content(challengeDTOList)
+				.pageable(challengePage.getPageable())
+				.totalPages(challengePage.getTotalPages())
+				.totalElements(challengePage.getTotalElements())
+				.first(challengePage.isFirst())
+				.last(challengePage.isLast())
+				.numberOfElements(challengePage.getNumberOfElements())
+				.size(challengePage.getSize())
+				.number(challengePage.getNumber())
+				.sort(challengePage.getSort())
+				.build();
 	}
 
 }

--- a/src/main/java/grabit/grabit_backend/dto/ResponsePagingDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/ResponsePagingDTO.java
@@ -1,0 +1,29 @@
+package grabit.grabit_backend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class ResponsePagingDTO {
+	public List<ResponseChallengeDTO> content;
+	public Pageable pageable;
+	public int totalPages;
+	public long totalElements;
+	public boolean first;
+	public boolean last;
+	public int numberOfElements;
+	public int size;
+	public int number;
+	public Sort sort;
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -1,13 +1,13 @@
 package grabit.grabit_backend.repository;
 
 import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
-	List<Challenge> findAllChallengeWithPaging(Pageable pageable);
+	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -1,8 +1,12 @@
 package grabit.grabit_backend.repository;
 
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -33,12 +37,17 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	}
 
 	@Override
-	public List<Challenge> findAllChallengeWithPaging(Pageable pageable) {
-		return jpaQueryFactory
+	public Page<Challenge> findAllChallengeWithPaging(Pageable pageable) {
+		List<Challenge> content = jpaQueryFactory
 				.selectFrom(challenge)
 				.join(challenge.userChallengeList, userChallenge).fetchJoin()
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge);
+
+		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
 	}
 }

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -139,7 +139,7 @@ public class ChallengeService {
 	 * @return
 	 */
 	@Transactional
-	public List<Challenge> findAllChallengeWithPage(Integer page, Integer size){
+	public Page<Challenge> findAllChallengeWithPage(Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
 		return challengeRepository.findAllChallengeWithPaging(pageRequest);
 	}


### PR DESCRIPTION
## 배경(Backgroud)

* paging으로 직접 frontend에게 전달하면 원하는 데이터 형식을 줄 수 없었기 때문에 따로 paing DTO를 만들어서 전달함.
* frontend에서 원하는 challenge 정보와 paging정보를 담아서 반환하도록 수정.
* 변환 과정이 많아서 부하가 걸릴 수 있을 것 같은데, paging을 DTO로 넘기는 방법 말고 자체적으로 수정하는 방법을 찾아보려고 했으나 실패함.


## 변경사항(Changes)

* ResponsePaingDTO를 만들어서 frontend에서 원하는 정보만 담아서 보내도록 함. (5d20722)
* LIst -> Paging으로 반환을 바꾼 것은 Pagable 객체 안에 있는 값들을 get으로 쉽게 받아 올 수 있어서 수정.


## 결과(Result)

* challenge에 대한 정보를 API 명세서에 맞게 가공해서 넘겨줌.

