### PR TITLE
feat: get user's joined challenge list api 작성

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/UserController.java
+++ b/src/main/java/grabit/grabit_backend/controller/UserController.java
@@ -44,6 +44,7 @@ public class UserController {
     public ResponseEntity<ResponsePagingDTO> getJoinedChallengeList(@AuthenticationPrincipal User user,
                                                                     @RequestParam(defaultValue = "1") Integer page,
                                                                     @RequestParam(defaultValue = "5") Integer size) {
+        if (page < 1) page = 1;
         page = page - 1;
         Page<Challenge> challenges = challengeService.findUserJoinedChallengeList(user, page, size);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(challenges));

--- a/src/main/java/grabit/grabit_backend/controller/UserController.java
+++ b/src/main/java/grabit/grabit_backend/controller/UserController.java
@@ -1,13 +1,18 @@
 package grabit.grabit_backend.controller;
 
+import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
+import grabit.grabit_backend.dto.ResponseChallengeDTO;
+import grabit.grabit_backend.dto.ResponsePagingDTO;
 import grabit.grabit_backend.dto.ResponseUserDTO;
 import grabit.grabit_backend.dto.UpdateUserDTO;
+import grabit.grabit_backend.service.ChallengeService;
 import grabit.grabit_backend.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
 
 import javax.validation.Valid;
 
@@ -16,9 +21,11 @@ import javax.validation.Valid;
 public class UserController {
 
     private final UserService userService;
+    private final ChallengeService challengeService;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, ChallengeService challengeService) {
         this.userService = userService;
+        this.challengeService = challengeService;
     }
     @GetMapping("")
     public ResponseEntity<ResponseUserDTO> getUser(@AuthenticationPrincipal User user) {
@@ -29,9 +36,17 @@ public class UserController {
     @PatchMapping("")
     public ResponseEntity<ResponseUserDTO> updateUser(@AuthenticationPrincipal User user,
                                                       @Valid @RequestBody UpdateUserDTO dto) {
-        System.out.println(dto.getId());
         ResponseUserDTO resDTO = new ResponseUserDTO(userService.updateUser(dto, user));
         return ResponseEntity.status(HttpStatus.OK).body(resDTO);
+    }
+
+    @GetMapping("challenges")
+    public ResponseEntity<ResponsePagingDTO> getJoinedChallengeList(@AuthenticationPrincipal User user,
+                                                                    @RequestParam(defaultValue = "1") Integer page,
+                                                                    @RequestParam(defaultValue = "5") Integer size) {
+        page = page - 1;
+        Page<Challenge> challenges = challengeService.findUserJoinedChallengeList(user, page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(challenges));
     }
 
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -1,6 +1,7 @@
 package grabit.grabit_backend.repository;
 
 import grabit.grabit_backend.domain.Challenge;
+import grabit.grabit_backend.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,4 +11,5 @@ public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
 	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
+	Page<Challenge> findUserJoinedChallengeList(Pageable pageable, User user);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -9,8 +9,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.util.List;
 import java.util.Optional;
 
@@ -26,8 +24,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	public ChallengeCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory){
 		this.jpaQueryFactory = jpaQueryFactory;
 	}
-	@PersistenceContext
-	private EntityManager entityManager;
+
 	@Override
 	public Optional<Challenge> findChallengeById(Long id) {
 		return Optional.ofNullable(jpaQueryFactory
@@ -60,7 +57,8 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 				.join(challenge.userChallengeList, userChallenge).fetchJoin()
 				.where(userChallenge.user.eq(u))
 				.offset(pageable.getOffset())
-				.limit(pageable.getPageSize()).fetch();
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc()).fetch();
 
 		JPAQuery<Challenge> query = jpaQueryFactory.selectFrom(challenge)
 				.join(challenge.userChallengeList, userChallenge).fetchJoin()

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -182,5 +182,10 @@ public class ChallengeService {
 		}
 		return findChallenge.get();
 	}
+
+	public Page<Challenge> findUserJoinedChallengeList(User user, Integer page, Integer size) {
+		PageRequest pageRequest = PageRequest.of(page, size);
+		return challengeRepository.findUserJoinedChallengeList(pageRequest, user);
+	}
 }
 


### PR DESCRIPTION
## 배경(Backgroud)

* 유저가 가입되어있는 챌린지 목록 조회하는 api 필요 


## 변경사항(Changes)

* `/api/users/challenges` endpoint로 생성 
* pagination api의 page 쿼리를 0이아니라 1부터 보내는 것으로 변경 
    * 모든 pagination api를 동일하게 수정해야함  

## 결과(Result)

response body는 기존에 있던 챌린지 목록 조회 api와 동일 
```
{
    "content": [
        {
            "id": 1,
            "name": "야호",
            "description": "설명",
            "leader": "sally0226",
            "isPrivate": false,
            "member": [
                "sally0226"
            ]
        }
    ],
    "pageable": {
        "sort": {
            "empty": true,
            "sorted": false,
            "unsorted": true
        },
        "offset": 0,
        "pageNumber": 0,
        "pageSize": 5,
        "paged": true,
        "unpaged": false
    },
    "totalPages": 1,
    "totalElements": 1,
    "first": true,
    "last": true,
    "numberOfElements": 1,
    "size": 5,
    "number": 0,
    "sort": {
        "empty": true,
        "sorted": false,
        "unsorted": true
    }
}
```