### PR TITLE
[Challenge] Search 기능 추가, 정렬 기준 변경.

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -43,12 +43,21 @@ public class ChallengeController {
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
-	@GetMapping(value = "name")
+	/**
+	 * 모든 챌린지 정보 조회 (search) with Paing API
+	 * @param page
+	 * @param size
+	 * @param name
+	 * @return
+	 */
+	@GetMapping(value = "search")
 	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
 																			@RequestParam(defaultValue = "5") Integer size,
-																			@RequestParam(defaultValue = "") String name) {
-		Page<Challenge> findChallengeByNameWithPage = challengeService.findChallengeByNameWithPage(name, page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeByNameWithPage));
+																			@RequestParam(required = false) String title,
+																			@RequestParam(defaultValue = "",required = false) String description,
+																			@RequestParam(required = false) String leaderId) {
+		Page<Challenge> findChallengeBySearchWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeBySearchWithPage));
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -39,6 +39,7 @@ public class ChallengeController {
 	@GetMapping(value = "")
 	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
 																		  @RequestParam(defaultValue = "5") Integer size){
+		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
@@ -47,7 +48,9 @@ public class ChallengeController {
 	 * 모든 챌린지 정보 조회 (search) with Paing API
 	 * @param page
 	 * @param size
-	 * @param name
+	 * @param title
+	 * @param description
+	 * @param leaderId
 	 * @return
 	 */
 	@GetMapping(value = "search")
@@ -56,6 +59,7 @@ public class ChallengeController {
 																			@RequestParam(required = false) String title,
 																			@RequestParam(defaultValue = "",required = false) String description,
 																			@RequestParam(required = false) String leaderId) {
+		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengeBySearchWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeBySearchWithPage));
 	}

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -43,6 +43,14 @@ public class ChallengeController {
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
+	@GetMapping(value = "name")
+	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+																			@RequestParam(defaultValue = "5") Integer size,
+																			@RequestParam(defaultValue = "") String name) {
+		Page<Challenge> findChallengeByNameWithPage = challengeService.findChallengeByNameWithPage(name, page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeByNameWithPage));
+	}
+
 	/**
 	 * 챌린지 생성 API
 	 * @param createChallengeDTO

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -37,7 +37,7 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "")
-	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
 																		  @RequestParam(defaultValue = "5") Integer size){
 		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
@@ -54,7 +54,7 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "search")
-	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
 																			@RequestParam(defaultValue = "5") Integer size,
 																			@RequestParam(required = false) String title,
 																			@RequestParam(defaultValue = "",required = false) String description,

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -10,4 +10,5 @@ public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
 	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
+	Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -10,5 +10,6 @@ public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
 	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
-	Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable);
+	Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable);
+	Page<Challenge> findChallengeByLeaderIdWithPaging(String leaderId, Pageable pageable);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -52,10 +52,10 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	}
 
 	@Override
-	public Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable) {
+	public Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable) {
 		List<Challenge> content = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(name))
+				.where(challenge.name.eq(title), challenge.description.contains(description))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.orderBy(challenge.createdAt.desc())
@@ -63,7 +63,24 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(name));
+				.where(challenge.name.eq(title));
+
+		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+	}
+
+	@Override
+	public Page<Challenge> findChallengeByLeaderIdWithPaging(String leaderId, Pageable pageable) {
+		List<Challenge> content = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(leaderId))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(leaderId));
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
 	}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -55,7 +55,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	public Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable) {
 		List<Challenge> content = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(title), challenge.description.contains(description))
+				.where(challenge.name.contains(title), challenge.description.contains(description))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.orderBy(challenge.createdAt.desc())

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -49,4 +49,20 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
 	}
+
+	@Override
+	public Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable) {
+		List<Challenge> content = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.eq(name))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.eq(name));
+
+		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+	}
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -42,6 +42,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 				.selectFrom(challenge)
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
 				.fetch();
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory
@@ -57,6 +58,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 				.where(challenge.name.eq(name))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
 				.fetch();
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -123,16 +123,22 @@ public class ChallengeService {
 	}
 
 	/**
-	 * 챌린지 조회 (name) with Paging
+	 * 챌린지 조회 (search) with Paging
 	 * @param name
 	 * @param page
 	 * @param size
 	 * @return
 	 */
 	@Transactional
-	public Page<Challenge> findChallengeByNameWithPage(String name, Integer page, Integer size){
+	public Page<Challenge> findChallengeBySearchWithPage(String title, String description, String leaderId, Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
-		return challengeRepository.findChallengeByNameWithPaging(name, pageRequest);
+		if (leaderId == null && title == null){
+			throw new IllegalStateException("잘못된 요청입니다.");
+		}else if (leaderId != null){
+			return challengeRepository.findChallengeByLeaderIdWithPaging(leaderId, pageRequest);
+		}else {
+			return challengeRepository.findChallengeByTitleAndDescriptionWithPaging(title, description, pageRequest);
+		}
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -68,21 +68,6 @@ public class ChallengeService {
 	}
 
 	/**
-	 * 챌린지 조회 (name)
-	 * @param name
-	 * @return List of Challenge
-	 */
-	@Transactional
-	public ArrayList<ResponseChallengeDTO> findChallengeByName(String name){
-		List<Challenge> findChallenges = challengeRepository.findByName(name);
-		ArrayList<ResponseChallengeDTO> returnChallenges = new ArrayList<>();
-		for(Challenge challenge: findChallenges){
-			returnChallenges.add(ResponseChallengeDTO.convertDTO(challenge));
-		}
-		return returnChallenges;
-	}
-
-	/**
 	 * 챌린지 삭제
 	 * @param id
 	 */
@@ -135,6 +120,19 @@ public class ChallengeService {
 	public Page<Challenge> findAllChallengeWithPage(Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
 		return challengeRepository.findAllChallengeWithPaging(pageRequest);
+	}
+
+	/**
+	 * 챌린지 조회 (name) with Paging
+	 * @param name
+	 * @param page
+	 * @param size
+	 * @return
+	 */
+	@Transactional
+	public Page<Challenge> findChallengeByNameWithPage(String name, Integer page, Integer size){
+		PageRequest pageRequest = PageRequest.of(page, size);
+		return challengeRepository.findChallengeByNameWithPaging(name, pageRequest);
 	}
 
 	/**


### PR DESCRIPTION
## 배경(Backgroud)

* 챌린지 검색 시 최근 만들어진 순서대로 반환이 되어야 함.
* 이름, 소개, 리더의 이름으로 챌린지 검색이 필요한 API가 필요하게 됨.


## 변경사항(Changes)

* Challenge가 최근 만들어진 순서대로 반환되도록 수정. (38b8e559cb0c7bdcc1df7ca357ad1c97f98fa6b3)
* /api/challenges/search Path에 Query문을 통해 요청 할 수 있는 챌린지 검색 API 추가 (13c9473fec9b594ba58433881c6cc81fdfe7ef1d)
* page 조회 값의 default값이 1이 되도록 수정. 0이면 그대로 0을 반환하고 1 이상은 0부터 조회되도록 수정. (e61704c39e039349d0bafa77143c53f85274eb50)


## 결과(Result)

* /api/challenges/search? URL에 page, size, title, description, leaderId(Github ID)를 통해 조회할 수 있음.
* Challenge 반환 값의 페이지 값은 기본적으로 1부터 차례대로 조회 됨.


### 추가 정보(Additional Information)

