### PR TITLE
[refactor] #40 pr 리팩토링 (전체 챌린지 목록 조회 + 챌린지 검색)

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -1,10 +1,10 @@
 package grabit.grabit_backend.controller;
 
 import grabit.grabit_backend.domain.Challenge;
+import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import grabit.grabit_backend.dto.ResponseChallengeDTO;
-import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.dto.ResponsePagingDTO;
 import grabit.grabit_backend.service.ChallengeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,9 +15,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("challenges")
@@ -31,21 +28,7 @@ public class ChallengeController {
 	}
 
 	/**
-	 * 모든 챌린지 정보 조회 with Paing API
-	 * @param page
-	 * @param size
-	 * @return
-	 */
-	@GetMapping(value = "")
-	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
-																		  @RequestParam(defaultValue = "5") Integer size){
-		page = (page > 0) ? page-1 : page;
-		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
-	}
-
-	/**
-	 * 모든 챌린지 정보 조회 (search) with Paing API
+	 * 챌린지 목록 조회 (search) with Paing API
 	 * @param page
 	 * @param size
 	 * @param title
@@ -53,15 +36,15 @@ public class ChallengeController {
 	 * @param leaderId
 	 * @return
 	 */
-	@GetMapping(value = "search")
-	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
-																			@RequestParam(defaultValue = "5") Integer size,
-																			@RequestParam(required = false) String title,
-																			@RequestParam(defaultValue = "",required = false) String description,
-																			@RequestParam(required = false) String leaderId) {
+	@GetMapping(value = "")
+	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
+																		  @RequestParam(defaultValue = "5") Integer size,
+																		  @RequestParam(required = false) String title,
+																		  @RequestParam(defaultValue = "",required = false) String description,
+																		  @RequestParam(required = false) String leaderId){
 		page = (page > 0) ? page-1 : page;
-		Page<Challenge> findChallengeBySearchWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeBySearchWithPage));
+		Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -43,12 +43,21 @@ public class ChallengeController {
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
-	@GetMapping(value = "name")
+	/**
+	 * 모든 챌린지 정보 조회 (search) with Paing API
+	 * @param page
+	 * @param size
+	 * @param name
+	 * @return
+	 */
+	@GetMapping(value = "search")
 	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
 																			@RequestParam(defaultValue = "5") Integer size,
-																			@RequestParam(defaultValue = "") String name) {
-		Page<Challenge> findChallengeByNameWithPage = challengeService.findChallengeByNameWithPage(name, page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeByNameWithPage));
+																			@RequestParam(required = false) String title,
+																			@RequestParam(defaultValue = "",required = false) String description,
+																			@RequestParam(required = false) String leaderId) {
+		Page<Challenge> findChallengeBySearchWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeBySearchWithPage));
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -39,6 +39,7 @@ public class ChallengeController {
 	@GetMapping(value = "")
 	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
 																		  @RequestParam(defaultValue = "5") Integer size){
+		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
@@ -47,7 +48,9 @@ public class ChallengeController {
 	 * 모든 챌린지 정보 조회 (search) with Paing API
 	 * @param page
 	 * @param size
-	 * @param name
+	 * @param title
+	 * @param description
+	 * @param leaderId
 	 * @return
 	 */
 	@GetMapping(value = "search")
@@ -56,6 +59,7 @@ public class ChallengeController {
 																			@RequestParam(required = false) String title,
 																			@RequestParam(defaultValue = "",required = false) String description,
 																			@RequestParam(required = false) String leaderId) {
+		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengeBySearchWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeBySearchWithPage));
 	}

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -43,6 +43,14 @@ public class ChallengeController {
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}
 
+	@GetMapping(value = "name")
+	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+																			@RequestParam(defaultValue = "5") Integer size,
+																			@RequestParam(defaultValue = "") String name) {
+		Page<Challenge> findChallengeByNameWithPage = challengeService.findChallengeByNameWithPage(name, page, size);
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengeByNameWithPage));
+	}
+
 	/**
 	 * 챌린지 생성 API
 	 * @param createChallengeDTO

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -42,7 +42,7 @@ public class ChallengeController {
 																		  @RequestParam(required = false) String title,
 																		  @RequestParam(defaultValue = "",required = false) String description,
 																		  @RequestParam(required = false) String leaderId){
-		page = (page > 0) ? page-1 : page;
+		page = page - 1;
 		Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
 		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
 	}

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -37,7 +37,7 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "")
-	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
 																		  @RequestParam(defaultValue = "5") Integer size){
 		page = (page > 0) ? page-1 : page;
 		Page<Challenge> findChallengesWithPage = challengeService.findAllChallengeWithPage(page, size);
@@ -54,7 +54,7 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "search")
-	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "0") Integer page,
+	public ResponseEntity<ResponsePagingDTO> findChallengeByNameWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
 																			@RequestParam(defaultValue = "5") Integer size,
 																			@RequestParam(required = false) String title,
 																			@RequestParam(defaultValue = "",required = false) String description,

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -9,7 +9,5 @@ import java.util.Optional;
 public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
-	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
-	Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable);
-	Page<Challenge> findChallengeByLeaderIdWithPaging(String leaderId, Pageable pageable);
+	Page<Challenge> findChallengeBySearchWithPaging(Pageable pageable, String title, String description, String leaderId);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -10,4 +10,5 @@ public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
 	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
+	Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepository.java
@@ -10,5 +10,6 @@ public interface ChallengeCustomRepository {
 
 	Optional<Challenge> findChallengeById(Long id);
 	Page<Challenge> findAllChallengeWithPaging(Pageable pageable);
-	Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable);
+	Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable);
+	Page<Challenge> findChallengeByLeaderIdWithPaging(String leaderId, Pageable pageable);
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -52,10 +52,10 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	}
 
 	@Override
-	public Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable) {
+	public Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable) {
 		List<Challenge> content = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(name))
+				.where(challenge.name.eq(title), challenge.description.contains(description))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.orderBy(challenge.createdAt.desc())
@@ -63,7 +63,24 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(name));
+				.where(challenge.name.eq(title));
+
+		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+	}
+
+	@Override
+	public Page<Challenge> findChallengeByLeaderIdWithPaging(String leaderId, Pageable pageable) {
+		List<Challenge> content = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(leaderId))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(leaderId));
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
 	}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -55,7 +55,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 	public Page<Challenge> findChallengeByTitleAndDescriptionWithPaging(String title, String description, Pageable pageable) {
 		List<Challenge> content = jpaQueryFactory
 				.selectFrom(challenge)
-				.where(challenge.name.eq(title), challenge.description.contains(description))
+				.where(challenge.name.contains(title), challenge.description.contains(description))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
 				.orderBy(challenge.createdAt.desc())

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -49,4 +49,20 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 
 		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
 	}
+
+	@Override
+	public Page<Challenge> findChallengeByNameWithPaging(String name, Pageable pageable) {
+		List<Challenge> content = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.eq(name))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.eq(name));
+
+		return PageableExecutionUtils.getPage(content, pageable, () -> countQuery.fetch().size());
+	}
 }

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeCustomRepositoryImpl.java
@@ -42,6 +42,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 				.selectFrom(challenge)
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
 				.fetch();
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory
@@ -57,6 +58,7 @@ public class ChallengeCustomRepositoryImpl implements ChallengeCustomRepository{
 				.where(challenge.name.eq(name))
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
 				.fetch();
 
 		JPAQuery<Challenge> countQuery = jpaQueryFactory

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -123,16 +123,22 @@ public class ChallengeService {
 	}
 
 	/**
-	 * 챌린지 조회 (name) with Paging
+	 * 챌린지 조회 (search) with Paging
 	 * @param name
 	 * @param page
 	 * @param size
 	 * @return
 	 */
 	@Transactional
-	public Page<Challenge> findChallengeByNameWithPage(String name, Integer page, Integer size){
+	public Page<Challenge> findChallengeBySearchWithPage(String title, String description, String leaderId, Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
-		return challengeRepository.findChallengeByNameWithPaging(name, pageRequest);
+		if (leaderId == null && title == null){
+			throw new IllegalStateException("잘못된 요청입니다.");
+		}else if (leaderId != null){
+			return challengeRepository.findChallengeByLeaderIdWithPaging(leaderId, pageRequest);
+		}else {
+			return challengeRepository.findChallengeByTitleAndDescriptionWithPaging(title, description, pageRequest);
+		}
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -68,21 +68,6 @@ public class ChallengeService {
 	}
 
 	/**
-	 * 챌린지 조회 (name)
-	 * @param name
-	 * @return List of Challenge
-	 */
-	@Transactional
-	public ArrayList<ResponseChallengeDTO> findChallengeByName(String name){
-		List<Challenge> findChallenges = challengeRepository.findByName(name);
-		ArrayList<ResponseChallengeDTO> returnChallenges = new ArrayList<>();
-		for(Challenge challenge: findChallenges){
-			returnChallenges.add(ResponseChallengeDTO.convertDTO(challenge));
-		}
-		return returnChallenges;
-	}
-
-	/**
 	 * 챌린지 삭제
 	 * @param id
 	 */
@@ -135,6 +120,19 @@ public class ChallengeService {
 	public Page<Challenge> findAllChallengeWithPage(Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
 		return challengeRepository.findAllChallengeWithPaging(pageRequest);
+	}
+
+	/**
+	 * 챌린지 조회 (name) with Paging
+	 * @param name
+	 * @param page
+	 * @param size
+	 * @return
+	 */
+	@Transactional
+	public Page<Challenge> findChallengeByNameWithPage(String name, Integer page, Integer size){
+		PageRequest pageRequest = PageRequest.of(page, size);
+		return challengeRepository.findChallengeByNameWithPaging(name, pageRequest);
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -1,13 +1,12 @@
 package grabit.grabit_backend.service;
 
-import grabit.grabit_backend.dto.CreateChallengeDTO;
-import grabit.grabit_backend.dto.ModifyChallengeDTO;
-import grabit.grabit_backend.dto.ResponseChallengeDTO;
 import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
-import grabit.grabit_backend.repository.ChallengeRepository;
-import grabit.grabit_backend.exception.UnauthorizedException;
 import grabit.grabit_backend.domain.UserChallenge;
+import grabit.grabit_backend.dto.CreateChallengeDTO;
+import grabit.grabit_backend.dto.ModifyChallengeDTO;
+import grabit.grabit_backend.exception.UnauthorizedException;
+import grabit.grabit_backend.repository.ChallengeRepository;
 import grabit.grabit_backend.repository.UserChallengeRepository;
 import grabit.grabit_backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -117,28 +116,12 @@ public class ChallengeService {
 	 * @return
 	 */
 	@Transactional
-	public Page<Challenge> findAllChallengeWithPage(Integer page, Integer size){
-		PageRequest pageRequest = PageRequest.of(page, size);
-		return challengeRepository.findAllChallengeWithPaging(pageRequest);
-	}
-
-	/**
-	 * 챌린지 조회 (search) with Paging
-	 * @param name
-	 * @param page
-	 * @param size
-	 * @return
-	 */
-	@Transactional
 	public Page<Challenge> findChallengeBySearchWithPage(String title, String description, String leaderId, Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
-		if (leaderId == null && title == null){
+		if (leaderId == null && title == null && description == null){
 			throw new IllegalStateException("잘못된 요청입니다.");
-		}else if (leaderId != null){
-			return challengeRepository.findChallengeByLeaderIdWithPaging(leaderId, pageRequest);
-		}else {
-			return challengeRepository.findChallengeByTitleAndDescriptionWithPaging(title, description, pageRequest);
 		}
+		return challengeRepository.findChallengeBySearchWithPaging(pageRequest, title, description, leaderId);
 	}
 
 	/**


### PR DESCRIPTION
## 배경(Backgroud)

#40 
에서 현철님이 챌린지 검색 기능을 작성해주셨는데, (search_challenge)
전체 챌린지 목록 조회 기능과 챌린지 검색 기능을 하나로 합치면 좋을 것 같아서 리팩토링 해 보았습니다.

## 변경사항(Changes)

- #40 의 search_challenge 브랜치를 따서 작업했습니다.

- `/challenges` 한 개의 api 로 통일 
- 쿼리를 한 개도 안보내면 전체 챌린지 목록 조회로
- `title` or `description` or `leaderId`쿼리를 넣어보내면 해당 조건으로 필터링해서 조회하는 방식으로 작성했습니다.

## 결과(Result)

* 쿼리 유무에 따라 의도한 기능이 잘 동작함 