### PR TITLE
GET 챌린지 api 인증 해제

### DIFF
--- a/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
+++ b/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
@@ -91,6 +92,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/stomp/chat/**").permitAll()
                     .antMatchers("/").permitAll() // local에서 oauth로그인 시 redirect받을 링크
                     .antMatchers("/actuator/health").permitAll()
+                    .mvcMatchers(HttpMethod.GET, "/challenges").permitAll()
+                    .mvcMatchers(HttpMethod.GET, "/challenges/{id}").permitAll()
                     .antMatchers("/**").hasAnyRole("USER")
                 .and()
                 .oauth2Login()

--- a/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
+++ b/src/main/java/grabit/grabit_backend/config/security/SecurityConfig.java
@@ -92,8 +92,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/stomp/chat/**").permitAll()
                     .antMatchers("/").permitAll() // local에서 oauth로그인 시 redirect받을 링크
                     .antMatchers("/actuator/health").permitAll()
-                    .mvcMatchers(HttpMethod.GET, "/challenges").permitAll()
-                    .mvcMatchers(HttpMethod.GET, "/challenges/{id}").permitAll()
+                    .antMatchers(HttpMethod.GET, "/challenges").permitAll()
+                    .antMatchers(HttpMethod.GET, "/challenges/{id}").permitAll()
                     .antMatchers("/**").hasAnyRole("USER")
                 .and()
                 .oauth2Login()

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -103,13 +103,9 @@ public class ChallengeController {
      */
     @GetMapping(value = "{id}")
     public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user) {
-        Challenge challenge = challengeService.findChallengeById(id);
+        Challenge challenge = challengeService.findChallengeById(id, user);
 
-        if (!challenge.getIsPrivate())
-            return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(challenge));
 
-        if (user == null)
-            throw new UnauthorizedException();
 
         for (UserChallenge userChallenge : challenge.getUserChallengeList()) {
             if (userChallenge.getUser().getUserId().equals(user.getUserId()))

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -6,6 +6,7 @@ import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import grabit.grabit_backend.dto.ResponseChallengeDTO;
 import grabit.grabit_backend.dto.ResponsePagingDTO;
+import grabit.grabit_backend.exception.UnauthorizedException;
 import grabit.grabit_backend.service.ChallengeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -94,9 +95,12 @@ public class ChallengeController {
 	 * @return
 	 */
 	@GetMapping(value = "{id}")
-	public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id){
-		Challenge findChallenge = challengeService.findChallengeById(id);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(findChallenge));
+	public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user){
+		Challenge challenge = challengeService.findChallengeById(id);
+		if (challenge.getIsPrivate() && user == null) {
+			throw new UnauthorizedException();
+		}
+		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(challenge));
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package grabit.grabit_backend.controller;
 
 import grabit.grabit_backend.domain.Challenge;
 import grabit.grabit_backend.domain.User;
+import grabit.grabit_backend.domain.UserChallenge;
 import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import grabit.grabit_backend.dto.ResponseChallengeDTO;
@@ -16,116 +17,133 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RestController
 @RequestMapping("challenges")
 public class ChallengeController {
 
-	private final ChallengeService challengeService;
+    private final ChallengeService challengeService;
 
-	@Autowired
-	public ChallengeController(ChallengeService challengeService) {
-		this.challengeService = challengeService;
-	}
+    @Autowired
+    public ChallengeController(ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
 
-	/**
-	 * 챌린지 목록 조회 (search) with Paing API
-	 * @param page
-	 * @param size
-	 * @param title
-	 * @param description
-	 * @param leaderId
-	 * @return
-	 */
-	@GetMapping(value = "")
-	public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
-																		  @RequestParam(defaultValue = "5") Integer size,
-																		  @RequestParam(required = false) String title,
-																		  @RequestParam(defaultValue = "",required = false) String description,
-																		  @RequestParam(required = false) String leaderId){
-		page = page - 1;
-		Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
-	}
+    /**
+     * 챌린지 목록 조회 (search) with Paing API
+     *
+     * @param page
+     * @param size
+     * @param title
+     * @param description
+     * @param leaderId
+     * @return
+     */
+    @GetMapping(value = "")
+    public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
+                                                                          @RequestParam(defaultValue = "5") Integer size,
+                                                                          @RequestParam(required = false) String title,
+                                                                          @RequestParam(defaultValue = "", required = false) String description,
+                                                                          @RequestParam(required = false) String leaderId) {
+        page = page - 1;
+        Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
+    }
 
-	/**
-	 * 챌린지 생성 API
-	 * @param createChallengeDTO
-	 * @param user
-	 * @return responseEntity
-	 */
-	@PostMapping(value = "")
-	public ResponseEntity<ResponseChallengeDTO> createChallengeAPI(@Valid @RequestBody CreateChallengeDTO createChallengeDTO,
-																   @AuthenticationPrincipal User user){
-		Challenge createdChallenge = challengeService.createChallenge(createChallengeDTO, user);
-		return ResponseEntity.status(HttpStatus.CREATED).body(ResponseChallengeDTO.convertDTO(createdChallenge));
-	}
+    /**
+     * 챌린지 생성 API
+     *
+     * @param createChallengeDTO
+     * @param user
+     * @return responseEntity
+     */
+    @PostMapping(value = "")
+    public ResponseEntity<ResponseChallengeDTO> createChallengeAPI(@Valid @RequestBody CreateChallengeDTO createChallengeDTO,
+                                                                   @AuthenticationPrincipal User user) {
+        Challenge createdChallenge = challengeService.createChallenge(createChallengeDTO, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseChallengeDTO.convertDTO(createdChallenge));
+    }
 
-	/**
-	 * 챌린지 수정 API
-	 * @param id
-	 * @param modifyChallengeDTO
-	 * @param user
-	 * @return responseEntity
-	 */
-	@PatchMapping(value = "{id}")
-	public ResponseEntity<ResponseChallengeDTO> updateChallengeAPI(@PathVariable(value = "id") Long id,
-																   @Valid @RequestBody ModifyChallengeDTO modifyChallengeDTO,
-																   @AuthenticationPrincipal User user){
-		Challenge modifiedChallenge = challengeService.updateChallenge(id, modifyChallengeDTO, user);
-		return ResponseEntity.status(HttpStatus.CREATED).body(ResponseChallengeDTO.convertDTO(modifiedChallenge));
-	}
+    /**
+     * 챌린지 수정 API
+     *
+     * @param id
+     * @param modifyChallengeDTO
+     * @param user
+     * @return responseEntity
+     */
+    @PatchMapping(value = "{id}")
+    public ResponseEntity<ResponseChallengeDTO> updateChallengeAPI(@PathVariable(value = "id") Long id,
+                                                                   @Valid @RequestBody ModifyChallengeDTO modifyChallengeDTO,
+                                                                   @AuthenticationPrincipal User user) {
+        Challenge modifiedChallenge = challengeService.updateChallenge(id, modifyChallengeDTO, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ResponseChallengeDTO.convertDTO(modifiedChallenge));
+    }
 
-	/**
-	 * 챌린지 삭제 API
-	 * @param id
-	 * @param user
-	 * @return responseEntity
-	 */
-	@DeleteMapping(value = "{id}")
-	public ResponseEntity<Void> deleteChallengeAPI(@PathVariable(value = "id") Long id,
-												   @AuthenticationPrincipal User user){
-		challengeService.deleteChallengeById(id, user);
-		return ResponseEntity.status(HttpStatus.OK).build();
-	}
+    /**
+     * 챌린지 삭제 API
+     *
+     * @param id
+     * @param user
+     * @return responseEntity
+     */
+    @DeleteMapping(value = "{id}")
+    public ResponseEntity<Void> deleteChallengeAPI(@PathVariable(value = "id") Long id,
+                                                   @AuthenticationPrincipal User user) {
+        challengeService.deleteChallengeById(id, user);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 
-	/**
-	 * 챌린지 정보 조회 API
-	 * @param id
-	 * @return
-	 */
-	@GetMapping(value = "{id}")
-	public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user){
-		Challenge challenge = challengeService.findChallengeById(id);
-		if (challenge.getIsPrivate() && user == null) {
-			throw new UnauthorizedException();
-		}
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(challenge));
-	}
+    /**
+     * 챌린지 정보 조회 API
+     *
+     * @param id
+     * @return
+     */
+    @GetMapping(value = "{id}")
+    public ResponseEntity<ResponseChallengeDTO> findChallengeAPI(@PathVariable(value = "id") Long id, @AuthenticationPrincipal User user) {
+        Challenge challenge = challengeService.findChallengeById(id);
 
-	/**
-	 * 챌린지 가입 API
-	 * @param id
-	 * @param user
-	 * @return
-	 */
-	@PatchMapping(value = "{id}/join")
-	public ResponseEntity<ResponseChallengeDTO> joinChallengeAPI(@PathVariable(value = "id") Long id,
-																 @AuthenticationPrincipal User user){
-		Challenge joinChallenge = challengeService.joinChallenge(id, user);
-		return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(joinChallenge));
-	}
+        if (!challenge.getIsPrivate())
+            return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(challenge));
 
-	/**
-	 * 챌린지 탈퇴 API
-	 * @param id
-	 * @param user
-	 * @return
-	 */
-	@PatchMapping(value = "{id}/leave")
-	public ResponseEntity<Void> leaveChallengeAPI(@PathVariable(value = "id") Long id,
-												  @AuthenticationPrincipal User user){
-		challengeService.leaveChallenge(id, user);
-		return ResponseEntity.status(HttpStatus.OK).build();
-	}
+        if (user == null)
+            throw new UnauthorizedException();
+
+        for (UserChallenge userChallenge : challenge.getUserChallengeList()) {
+            if (userChallenge.getUser().getUserId().equals(user.getUserId()))
+                return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(challenge));
+        }
+        throw new UnauthorizedException();
+    }
+
+    /**
+     * 챌린지 가입 API
+     *
+     * @param id
+     * @param user
+     * @return
+     */
+    @PatchMapping(value = "{id}/join")
+    public ResponseEntity<ResponseChallengeDTO> joinChallengeAPI(@PathVariable(value = "id") Long id,
+                                                                 @AuthenticationPrincipal User user) {
+        Challenge joinChallenge = challengeService.joinChallenge(id, user);
+        return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertDTO(joinChallenge));
+    }
+
+    /**
+     * 챌린지 탈퇴 API
+     *
+     * @param id
+     * @param user
+     * @return
+     */
+    @PatchMapping(value = "{id}/leave")
+    public ResponseEntity<Void> leaveChallengeAPI(@PathVariable(value = "id") Long id,
+                                                  @AuthenticationPrincipal User user) {
+        challengeService.leaveChallenge(id, user);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }
+

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -61,9 +61,19 @@ public class ChallengeService {
 	 * @return Challenge
 	 */
 	@Transactional
-	public Challenge findChallengeById(Long id){
+	public Challenge findChallengeById(Long id, User user){
 		Challenge challenge = isExistChallenge(id);
-		return challenge;
+		if (!challenge.getIsPrivate())
+			return challenge;
+
+		if (user == null)
+			throw new UnauthorizedException();
+
+		for (UserChallenge userChallenge : challenge.getUserChallengeList()) {
+			if (userChallenge.getUser().getUserId().equals(user.getUserId()))
+				return challenge;
+		}
+		throw new UnauthorizedException();
 	}
 
 	/**


### PR DESCRIPTION
## 배경(Backgroud)

* 가입 안한 사용자도 확인할 수 있게 하기 위해서  get challenge, get challenge list 두 api의 인증을 해제해야함

## 변경사항(Changes)

- get challenge의 경우, public 일 때만 인증 해제 / private일 때는 챌린지 멤버만 접근 가능하도록
- spring security 설정 변경

## 결과(Result)

* `/challenges`
    - 인증 해제 
- `/challenges/:id`
    - public : 인증 해제
    - private : 챌린지 멤버만 200, 나머지는 401


### 추가 정보(Additional Information)

private챌린지 일 때, 챌린지 멤버인지 체크하는 로직이 존재하는데  더 나은 로직이 있으면 알려주세용
디비 접근 추가로 안하고 싶어서, 최대한 주어진 정보에서 확인하는 방향으로 짜놨습니다.