### PR TITLE
[Challenge] Search Logic 수정.

### DIFF
--- a/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
+++ b/src/main/java/grabit/grabit_backend/controller/ChallengeController.java
@@ -7,7 +7,14 @@ import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
 import grabit.grabit_backend.dto.ResponseChallengeDTO;
 import grabit.grabit_backend.dto.ResponsePagingDTO;
+import grabit.grabit_backend.dto.SearchChallengeDTO;
+import grabit.grabit_backend.enums.SearchType;
 import grabit.grabit_backend.exception.UnauthorizedException;
+import grabit.grabit_backend.repository.ChallengeSearchRepository;
+import grabit.grabit_backend.repository.ChallengeSearchWithDesc;
+import grabit.grabit_backend.repository.ChallengeSearchWithLeader;
+import grabit.grabit_backend.repository.ChallengeSearchWithTitle;
+import grabit.grabit_backend.repository.ChallengeSearchWithTitleAndDesc;
 import grabit.grabit_backend.service.ChallengeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -42,11 +49,9 @@ public class ChallengeController {
     @GetMapping(value = "")
     public ResponseEntity<ResponsePagingDTO> findAllChallengesWithPageAPI(@RequestParam(defaultValue = "1") Integer page,
                                                                           @RequestParam(defaultValue = "5") Integer size,
-                                                                          @RequestParam(required = false) String title,
-                                                                          @RequestParam(defaultValue = "", required = false) String description,
-                                                                          @RequestParam(required = false) String leaderId) {
+                                                                          @RequestBody SearchChallengeDTO searchChallengeDTO) {
         page = page - 1;
-        Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(title, description, leaderId, page, size);
+        Page<Challenge> findChallengesWithPage = challengeService.findChallengeBySearchWithPage(searchChallengeDTO, page, size);
         return ResponseEntity.status(HttpStatus.OK).body(ResponseChallengeDTO.convertPageDTO(findChallengesWithPage));
     }
 

--- a/src/main/java/grabit/grabit_backend/dto/SearchChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/SearchChallengeDTO.java
@@ -12,7 +12,7 @@ import javax.validation.constraints.NotNull;
 public class SearchChallengeDTO {
 
 	@NotNull
-	SearchType type;
+	String type;
 
 	@NotNull
 	String content;

--- a/src/main/java/grabit/grabit_backend/dto/SearchChallengeDTO.java
+++ b/src/main/java/grabit/grabit_backend/dto/SearchChallengeDTO.java
@@ -1,0 +1,20 @@
+package grabit.grabit_backend.dto;
+
+import grabit.grabit_backend.enums.SearchType;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+public class SearchChallengeDTO {
+
+	@NotNull
+	SearchType type;
+
+	@NotNull
+	String content;
+
+}

--- a/src/main/java/grabit/grabit_backend/enums/SearchType.java
+++ b/src/main/java/grabit/grabit_backend/enums/SearchType.java
@@ -1,0 +1,8 @@
+package grabit.grabit_backend.enums;
+
+public enum SearchType {
+	title,
+	desc,
+	leader,
+	title_desc
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeSearchRepository.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeSearchRepository.java
@@ -1,0 +1,9 @@
+package grabit.grabit_backend.repository;
+
+import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ChallengeSearchRepository {
+	Page<Challenge> findChallengeWithPaing(Pageable pageable, String content);
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithDesc.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithDesc.java
@@ -1,0 +1,40 @@
+package grabit.grabit_backend.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static grabit.grabit_backend.domain.QChallenge.*;
+
+@Repository
+public class ChallengeSearchWithDesc implements ChallengeSearchRepository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public ChallengeSearchWithDesc(JPAQueryFactory jpaQueryFactory){
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public Page<Challenge> findChallengeWithPaing(Pageable pageable, String content) {
+		List<Challenge> challenges = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.description.contains(content))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.description.contains(content));
+
+		return PageableExecutionUtils.getPage(challenges, pageable, () -> countQuery.fetch().size());
+	}
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithLeader.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithLeader.java
@@ -1,0 +1,40 @@
+package grabit.grabit_backend.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static grabit.grabit_backend.domain.QChallenge.*;
+
+@Repository
+public class ChallengeSearchWithLeader implements ChallengeSearchRepository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public ChallengeSearchWithLeader(JPAQueryFactory jpaQueryFactory){
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public Page<Challenge> findChallengeWithPaing(Pageable pageable, String content) {
+		List<Challenge> challenges = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(content))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.leader.userId.eq(content));
+
+		return PageableExecutionUtils.getPage(challenges, pageable, () -> countQuery.fetch().size());
+	}
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithTitle.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithTitle.java
@@ -1,0 +1,40 @@
+package grabit.grabit_backend.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static grabit.grabit_backend.domain.QChallenge.*;
+
+@Repository
+public class ChallengeSearchWithTitle implements ChallengeSearchRepository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public ChallengeSearchWithTitle(JPAQueryFactory jpaQueryFactory){
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public Page<Challenge> findChallengeWithPaing(Pageable pageable, String content) {
+		List<Challenge> challenges = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.contains(content))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.contains(content));
+
+		return PageableExecutionUtils.getPage(challenges, pageable, () -> countQuery.fetch().size());
+	}
+}

--- a/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithTitleAndDesc.java
+++ b/src/main/java/grabit/grabit_backend/repository/ChallengeSearchWithTitleAndDesc.java
@@ -1,0 +1,40 @@
+package grabit.grabit_backend.repository;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import grabit.grabit_backend.domain.Challenge;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static grabit.grabit_backend.domain.QChallenge.*;
+
+@Repository
+public class ChallengeSearchWithTitleAndDesc implements ChallengeSearchRepository{
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public ChallengeSearchWithTitleAndDesc(JPAQueryFactory jpaQueryFactory){
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public Page<Challenge> findChallengeWithPaing(Pageable pageable, String content) {
+		List<Challenge> challenges = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.contains(content).or(challenge.description.contains(content)))
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(challenge.createdAt.desc())
+				.fetch();
+
+		JPAQuery<Challenge> countQuery = jpaQueryFactory
+				.selectFrom(challenge)
+				.where(challenge.name.contains(content).or(challenge.description.contains(content)));
+
+		return PageableExecutionUtils.getPage(challenges, pageable, () -> countQuery.fetch().size());
+	}
+}

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -5,8 +5,15 @@ import grabit.grabit_backend.domain.User;
 import grabit.grabit_backend.domain.UserChallenge;
 import grabit.grabit_backend.dto.CreateChallengeDTO;
 import grabit.grabit_backend.dto.ModifyChallengeDTO;
+import grabit.grabit_backend.dto.SearchChallengeDTO;
+import grabit.grabit_backend.enums.SearchType;
 import grabit.grabit_backend.exception.UnauthorizedException;
 import grabit.grabit_backend.repository.ChallengeRepository;
+import grabit.grabit_backend.repository.ChallengeSearchRepository;
+import grabit.grabit_backend.repository.ChallengeSearchWithDesc;
+import grabit.grabit_backend.repository.ChallengeSearchWithLeader;
+import grabit.grabit_backend.repository.ChallengeSearchWithTitle;
+import grabit.grabit_backend.repository.ChallengeSearchWithTitleAndDesc;
 import grabit.grabit_backend.repository.UserChallengeRepository;
 import grabit.grabit_backend.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,13 +32,25 @@ public class ChallengeService {
 	private final ChallengeRepository challengeRepository;
 	private final UserChallengeRepository userChallengeRepository;
 	private final UserRepository userRepository;
+	private final ChallengeSearchWithTitle challengeSearchWithTitle;
+	private final ChallengeSearchWithDesc challengeSearchWithDesc;
+	private final ChallengeSearchWithTitleAndDesc challengeSearchWithTitleAndDesc;
+	private final ChallengeSearchWithLeader challengeSearchWithLeader;
 
 	public ChallengeService(ChallengeRepository challengeRepository,
 							UserChallengeRepository userChallengeRepository,
-							UserRepository userRepository){
+							UserRepository userRepository,
+							ChallengeSearchWithTitle challengeSearchWithTitle,
+							ChallengeSearchWithDesc challengeSearchWithDesc,
+							ChallengeSearchWithTitleAndDesc challengeSearchWithTitleAndDesc,
+							ChallengeSearchWithLeader challengeSearchWithLeader){
 		this.challengeRepository = challengeRepository;
 		this.userChallengeRepository = userChallengeRepository;
 		this.userRepository = userRepository;
+		this.challengeSearchWithTitle = challengeSearchWithTitle;
+		this.challengeSearchWithDesc = challengeSearchWithDesc;
+		this.challengeSearchWithTitleAndDesc = challengeSearchWithTitleAndDesc;
+		this.challengeSearchWithLeader = challengeSearchWithLeader;
 	}
 
 	/**
@@ -125,12 +144,25 @@ public class ChallengeService {
 	 * @return
 	 */
 	@Transactional
-	public Page<Challenge> findChallengeBySearchWithPage(String title, String description, String leaderId, Integer page, Integer size){
+	public Page<Challenge> findChallengeBySearchWithPage(SearchChallengeDTO searchChallengeDTO, Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
-		if (leaderId == null && title == null && description == null){
-			throw new IllegalStateException("잘못된 요청입니다.");
+
+		SearchType searchType = searchChallengeDTO.getType();
+		ChallengeSearchRepository challengeSearchRepository = null;
+
+		if (searchType.equals(SearchType.title)) {
+			challengeSearchRepository = challengeSearchWithTitle;
+		} else if (searchType.equals(SearchType.desc)) {
+			challengeSearchRepository = challengeSearchWithDesc;
+		} else if (searchType.equals(SearchType.title_desc)) {
+			challengeSearchRepository = challengeSearchWithTitleAndDesc;
+		} else if (searchType.equals(SearchType.leader)) {
+			challengeSearchRepository = challengeSearchWithLeader;
+		} else {
+			throw new IllegalStateException("잘못된 SearchType 입니다.");
 		}
-		return challengeRepository.findChallengeBySearchWithPaging(pageRequest, title, description, leaderId);
+
+		return challengeSearchRepository.findChallengeWithPaing(pageRequest, searchChallengeDTO.getContent());
 	}
 
 	/**

--- a/src/main/java/grabit/grabit_backend/service/ChallengeService.java
+++ b/src/main/java/grabit/grabit_backend/service/ChallengeService.java
@@ -146,9 +146,8 @@ public class ChallengeService {
 	@Transactional
 	public Page<Challenge> findChallengeBySearchWithPage(SearchChallengeDTO searchChallengeDTO, Integer page, Integer size){
 		PageRequest pageRequest = PageRequest.of(page, size);
-
-		SearchType searchType = searchChallengeDTO.getType();
 		ChallengeSearchRepository challengeSearchRepository = null;
+		SearchType searchType = SearchType.valueOf(searchChallengeDTO.getType());
 
 		if (searchType.equals(SearchType.title)) {
 			challengeSearchRepository = challengeSearchWithTitle;


### PR DESCRIPTION
## 배경(Backgroud)

* Search Challenge 를 카테고리로 나누어서 받기로 함.
* Type, Content 두 필드를 받는 DTO와 그에 따른 다른 Logic 필요.


## 변경사항(Changes)

* SearchType과 Content를 받는 DTO 작성, 공통 interface를 통해 Service에서 동작할 수 있도록 작성.(30d1486d292528ba314992f181d9f66fee64f1ea)
* DTO의 type file를 Enum -> String으로 변경. 이유: Enum으로 바로 받으면 이상한 type이 들어왔을 때 에러 체크가 WARN으로 떠서 보기 힘듦. (0d7440151dd027c3b5a2ed5981d1d5d8ee1d0492)


## 결과(Result)

* 적절한 Type에 맞춰서 Challenge Search 동작함.


### 추가 정보(Additional Information)

